### PR TITLE
Additional connectionStrategy + some small things

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -72,4 +72,13 @@ connectionStrategy: function(tenantInformation, done) {
 }
 ```
 
+Alternatively, it can be an object whose values are either functions or values, which are assigned to the `req` object using their respective key.
 
+```javascript
+connectionStrategy: {
+  foo: 'bar', // sets req.foo to 'bar'
+  baz: function(tenant, callback) {
+    callback(null, 'baz'); // sets req.baz to 'baz' - first argument is an error which will propagate to next(err)
+  }
+}
+```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "mocha test"
   },
   "dependencies": {
-    "async": "^1.4.2",
+    "async": "1.4.2"
+  },
+  "devDependencies": {
     "express": "4.x",
     "mocha": "1.x",
     "supertest": "0.x"

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-	  "test": "mocha test"
+    "test": "mocha test"
   },
   "dependencies": {
+    "async": "^1.4.2",
     "express": "4.x",
-    "supertest": "0.x",
-    "mocha": "1.x"
+    "mocha": "1.x",
+    "supertest": "0.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "",
   "version": "0.0.1",
   "private": true,
+  "scripts": {
+	  "test": "mocha test"
+  },
   "dependencies": {
     "express": "4.x",
     "supertest": "0.x",

--- a/test/multitenant.js
+++ b/test/multitenant.js
@@ -85,6 +85,21 @@ describe('multiTenant', function() {
         done();
       });
     });
+
+    it('is an object', function(done) {
+      execute({
+        connectionStrategy: {
+          tenantHost: function(tenant, done) {
+            done(null, tenant.host);
+          },
+          tenantCompany: tenantObj.company
+        }
+      }, done, function(req, res) {
+        assert.equal(req.tenantHost, tenantObj.host);
+        assert.equal(req.tenantCompany, tenantObj.company);
+        done();
+      });
+    });
   });
 });
 


### PR DESCRIPTION
This adds support for a connectionStrategy object, meaning multiple "resolved things" per tenant -- it's purely additive, and has tests and readme instructions.

I also cleaned up a few things related to the dev side of things.
